### PR TITLE
Fix runtime java.lang.ClassNotFoundException: im.ckk.cordova.exit error on android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@
   <platform name="android">
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="Exit">
-        <param name="android-package" value="im.ckk.cordova.exit" />
+        <param name="android-package" value="im.ckk.cordova.exit.Exit" />
       </feature>
     </config-file>
     <source-file src="src/android/Exit.java" target-dir="src/im/ckk/cordova/exit" />


### PR DESCRIPTION
Plugin.xml was using incorrect package name